### PR TITLE
Move main SpringApplication class to upper dmacc package

### DIFF
--- a/src/main/java/dmacc/RockPaperScissorsApplication.java
+++ b/src/main/java/dmacc/RockPaperScissorsApplication.java
@@ -1,4 +1,4 @@
-package rockpaperscissors;
+package dmacc;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;


### PR DESCRIPTION
Your Controller classes must be nested below in package hierarchy to the main SpringApplication class having the main() method.  The Application.java file was inside a totally different package.  So move it into the upper level 'dmacc' package and all your controllers will be scanned and used.